### PR TITLE
Remove dllexport/dllimport declspec from libmodplug headers

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -932,6 +932,8 @@ build_libmodplug() {
   generic_download_and_install http://sourceforge.net/projects/modplug-xmms/files/libmodplug/0.8.8.5/libmodplug-0.8.8.5.tar.gz/download libmodplug-0.8.8.5
   # unfortunately this sed isn't enough, though I think it should be [so we add --extra-libs=-lstdc++ to FFmpegs configure] http://trac.ffmpeg.org/ticket/1539
   sed -i 's/-lmodplug.*/-lmodplug -lstdc++/' "$PKG_CONFIG_PATH/libmodplug.pc" # huh ?? c++?
+  sed -i 's/__declspec(dllexport)//' "$mingw_w64_x86_64_prefix/include/libmodplug/modplug.h" #strip DLL import/export directives
+  sed -i 's/__declspec(dllimport)//' "$mingw_w64_x86_64_prefix/include/libmodplug/modplug.h"
 }
 
 build_libcaca() {


### PR DESCRIPTION
libmodplug now require stripping of the decoration for DLL
imports/exports, the easiest way to achieve it is a pair of sed commands
in the script.

Fix analogous to a commit to a similiar script that solves the problem:
https://github.com/jb-alvarado/media-autobuild_suite/commit/c6ca335008
