### PR TITLE
bumped minimum cmake version to 2.8.12 to match jiixyj/libebur128

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -63,8 +63,8 @@ check_missing_packages () {
 
   function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
-  if [[ $(version $version_have)  < $(version '2.8.10') ]]; then
-    echo "your cmake version is too old $version_have wanted 2.8.10"
+  if [[ $(version $version_have)  < $(version '2.8.12') ]]; then
+    echo "your cmake version is too old $version_have wanted 2.8.12"
     exit 1
   fi
 


### PR DESCRIPTION
When I need to update ffmpeg on my windows boxes I tend to just kick off a script on a vps somewhere, came back after the most recent attempt to find this instead of an ffmpeg.
exe 

```
Downloading (via git clone) libebur128_git from https://github.com/jiixyj/libebur128.git
...
Already on 'master'
Your branch is up-to-date with 'origin/master'.
Updating to latest libebur128_git git version [origin/master]...
...
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  CMake 2.8.12 or higher is required.  You are running version 2.8.11

-- Configuring incomplete, errors occurred!
```

Which is a bit of a pain because RHEL7 doesn't have 2.8.12 in any usual repo, but it seems like it might be worth flagging this up front.                                      

What is weird is that the line:

`cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)`

has been in[ jiixyj/libebur128/CMakeLists.txt ](https://github.com/jiixyj/libebur128/blob/master/CMakeLists.txt#L1) for over a year yet I've never had a build fail for this reason before.