### PR TITLE
fix avresample not being built

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1525,7 +1525,7 @@ build_ffmpeg() {
   fi
   # L-Smash Work requires avresample
   if [[ $build_lsw = y ]]; then
-    config_option="$config_options --enable-avresample"
+    config_options="$config_options --enable-avresample"
   fi
   
   config_options="$config_options --extra-libs=-lpsapi" # dlfcn [frei0r?] requires this, has no .pc file should put in frei0r.pc? ...


### PR DESCRIPTION
due to a missing 's'