### PR TITLE
Regression fix: wrong cross_prefix string

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1852,7 +1852,7 @@ if [[ $compiler_flavors == "multi" || $compiler_flavors == "win32" ]]; then
   export PATH="$path_addition:$original_path"
   export PKG_CONFIG_PATH="$cur_dir/cross_compilers/mingw-w64-i686/i686-w64-mingw32/lib/pkgconfig"
   bits_target=32
-  cross_prefix="$path_addition/i686-w64-mingw32-"
+  cross_prefix="$cur_dir/cross_compilers/mingw-w64-i686/bin/i686-w64-mingw32-"
   make_prefix_options="CC=${cross_prefix}gcc AR=${cross_prefix}ar PREFIX=$mingw_w64_x86_64_prefix RANLIB=${cross_prefix}ranlib LD=${cross_prefix}ld STRIP=${cross_prefix}strip CXX=${cross_prefix}g++"
   mkdir -p win32
   cd win32
@@ -1871,7 +1871,7 @@ if [[ $compiler_flavors == "multi" || $compiler_flavors == "win64" ]]; then
   export PKG_CONFIG_PATH="$cur_dir/cross_compilers/mingw-w64-x86_64/x86_64-w64-mingw32/lib/pkgconfig"
   mkdir -p x86_64
   bits_target=64
-  cross_prefix="$path_addition/bin/x86_64-w64-mingw32-"
+  cross_prefix="$cur_dir/cross_compilers/mingw-w64-x86_64/bin/x86_64-w64-mingw32-"
   make_prefix_options="CC=${cross_prefix}gcc AR=${cross_prefix}ar PREFIX=$mingw_w64_x86_64_prefix RANLIB=${cross_prefix}ranlib LD=${cross_prefix}ld STRIP=${cross_prefix}strip CXX=${cross_prefix}g++"
   cd x86_64
   build_dependencies


### PR DESCRIPTION
In commit f157632806fec7f96fe1bf97b6bac02d21fea1d7 , the x86_64 cross prefix is certainly wrong as it leads to /bin/bin.
For the i686 one, I'm not certain, but somehow not working for me. So to play safe, I'm proposing to revert that two lines to the old working one.