### PR TITLE
fix lsw-Vapoursynth output executable name

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1579,12 +1579,12 @@ build_ffmpeg() {
 
 build_lsw() {
    # Build L-Smash Works
-   build_ffmpeg # dependency, I think it wants static... :)
+   #build_ffmpeg # dependency, I think it wants static... :)
    echo "Cloning L-Smash Works Repo"
    do_git_checkout https://github.com/VFR-maniac/L-SMASH-Works.git lsw
    cd lsw/VapourSynth
    echo "Building LSW VapourSynth plugin"
-   do_configure "--prefix=$mingw_w64_x86_64_prefix --cross-prefix=$cross_prefix"
+   do_configure "--prefix=$mingw_w64_x86_64_prefix --cross-prefix=$cross_prefix --target-os=mingw"
    do_make_and_make_install
    # AviUtl is 32bit-only
    if [ "$bits_target" = "32" ]; then
@@ -1599,7 +1599,7 @@ build_lsw() {
 find_all_build_exes() {
   local found=""
 # NB that we're currently in the sandbox dir...
-  for file in `find . -name ffmpeg.exe` `find . -name ffmpeg_g.exe` `find . -name ffplay.exe` `find . -name MP4Box.exe` `find . -name mplayer.exe` `find . -name mencoder.exe` `find . -name avconv.exe` `find . -name avprobe.exe` `find . -name x264.exe` `find . -name writeavidmxf.exe` `find . -name writeaviddv50.exe` `find . -name rtmpdump.exe` `find . -name x265.exe` `find . -name ismindex.exe` `find . -name dvbtee.exe` `find . -name boxdumper.exe` `find . -name muxer.exe ` `find . -name remuxer.exe` `find . -name timelineeditor.exe` `find . -name lwcolor.auc` `find . -name lwdumper.auf` `find . -name lwinput.aui` `find . -name lwmuxer.auf`; do
+  for file in `find . -name ffmpeg.exe` `find . -name ffmpeg_g.exe` `find . -name ffplay.exe` `find . -name MP4Box.exe` `find . -name mplayer.exe` `find . -name mencoder.exe` `find . -name avconv.exe` `find . -name avprobe.exe` `find . -name x264.exe` `find . -name writeavidmxf.exe` `find . -name writeaviddv50.exe` `find . -name rtmpdump.exe` `find . -name x265.exe` `find . -name ismindex.exe` `find . -name dvbtee.exe` `find . -name boxdumper.exe` `find . -name muxer.exe ` `find . -name remuxer.exe` `find . -name timelineeditor.exe` `find . -name lwcolor.auc` `find . -name lwdumper.auf` `find . -name lwinput.aui` `find . -name lwmuxer.auf` `find . -name vslsmashsource.dll`; do
     found="$found $(readlink -f $file)"
   done
 


### PR DESCRIPTION
add target-os=mingw to fix the naming. Currently it gives a strange *.so file.
In addition, the build_ffmpeg line is a complete waste of build time. It is only useful in edge case when someone did not build ffmpeg but somehow directly called build_lsw.
Static is not an issue because the zeranoe build script by default... is static only
The issue reported for the vapoursynth plugin not building is due to QuickSync.

So either skip that unconditional ffmpeg rebuild, or check for ffmpeg libs before deciding rebuild or not.