### PR TITLE
dvbtee requires iconv for ISO6937 & ATSC text conversion

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1490,6 +1490,7 @@ build_libhdhomerun() {
 }
 
 build_dvbtee_app() {
+  build_iconv
   build_libcurl # it "can use this" so why not
 #  build_libhdhomerun # broken but possible dependency apparently :|
   do_git_checkout https://github.com/mkrufky/libdvbtee.git libdvbtee_git


### PR DESCRIPTION
```
functions.cpp:25:10: fatal error: iconv.h: No such file or directory
 #include <iconv.h>
          ^~~~~~~~~
compilation terminated.
Makefile:542: recipe for target 'functions.lo' failed
make[2]: *** [functions.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
atsctext.cpp:43:10: fatal error: iconv.h: No such file or directory
 #include <iconv.h>
          ^~~~~~~~~
compilation terminated.
Makefile:542: recipe for target 'atsctext.lo' failed
make[2]: *** [atsctext.lo] Error 1
```

closes #320