### PR TITLE
Fix wrong parameter for git merge

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -308,7 +308,9 @@ do_git_checkout() {
   else
     echo "doing git checkout $desired_branch"
     git checkout -f "$desired_branch" || exit 1
-    git merge "$desired_branch" || exit 1 # get incoming changes to a branch
+    if git show-ref --verify --quiet "refs/remotes/origin/$desired_branch"; then # $desired_branch is actually a branch, not a tag or commit
+      git merge "origin/$desired_branch" || exit 1 # get incoming changes to a branch
+    fi
   fi
 
   new_git_version=`git rev-parse HEAD`


### PR DESCRIPTION
If we are already in master branch, doing `git fetch && git checkout -f master && git merge master` will not merge the change. We should `git merge origin/master` instead. This fix an issue where ffmpeg won't get updated if ffmpeg-git-checkout-version is set to "master" explicitly.

Note: I am not very familar with git and have not done full test on this change. This change works well on my existing `sandbox`.