### PR TITLE
fix bash syntax error

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1703,7 +1703,7 @@ build_ffmpeg() {
 
     init_options="--pkg-config=pkg-config --pkg-config-flags=--static --extra-version=ffmpeg-windows-build-helpers --enable-version3 --disable-debug --disable-w32threads"
     if [[ $compiler_flavors != "native" ]]; then
-      init_options += " --arch=$arch --target-os=mingw32 --cross-prefix=$cross_prefix"
+      init_options+=" --arch=$arch --target-os=mingw32 --cross-prefix=$cross_prefix"
     fi
     if [[ `uname` =~ "5.1" ]]; then
       init_options+=" --disable-schannel"


### PR DESCRIPTION
simple syntax error fix due to excessive space around operator