### PR TITLE
Add --disable-spec to theora

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -931,7 +931,7 @@ build_libspeex() {
 build_libtheora() {
   do_git_checkout https://github.com/xiph/theora.git
   cd theora_git
-    generic_configure "--disable-doc --disable-oggtest --disable-vorbistest --disable-examples"
+    generic_configure "--disable-doc --disable-spec --disable-oggtest --disable-vorbistest --disable-examples"
     # 'examples/encoder_example.c' would otherwise cause problems; "encoder_example.c:56:15: error: static declaration of 'rint' follows non-static declaration". No more issues with latest libpng either.
     do_make_and_make_install
   cd ..


### PR DESCRIPTION
Otherwise `make` will fail in Fedora 28 with error messages:
```
x86_64-w64-mingw32-gcc -Wall -Wno-parentheses -O3 -fforce-addr -fomit-frame-pointer -finline-functions -funroll-loops -mtune=generic -O3    vp3huff.c   -o vp3huff
./vp3huff > vp3huff.tex
/bin/sh: ./vp3huff: cannot execute binary file: Exec format error
```