### PR TITLE
Add SVT-HEVC

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1338,6 +1338,31 @@ build_frei0r() {
   cd ..
 }
 
+build_svt-hevc() {
+  do_git_checkout https://github.com/OpenVisualCloud/SVT-HEVC.git
+  mkdir -p SVT-HEVC_git/release
+  cd SVT-HEVC_git/release
+    do_cmake_from_build_dir .. "-DCMAKE_BUILD_TYPE=Release"
+    do_make_and_make_install
+  cd ../..
+}
+
+build_svt-av1() {
+  do_git_checkout https://github.com/OpenVisualCloud/SVT-AV1.git
+  cd SVT-AV1_git/Build
+    do_cmake_from_build_dir .. "-DCMAKE_BUILD_TYPE=Release"
+    do_make_and_make_install
+  cd ../..
+}
+
+build_svt-vp9() {
+  do_git_checkout https://github.com/OpenVisualCloud/SVT-VP9.git
+  cd SVT-VP9_git/Build
+    do_cmake_from_build_dir ..
+    do_make_and_make_install
+  cd ../..
+}
+
 build_vidstab() {
   do_git_checkout https://github.com/georgmartius/vid.stab.git vid.stab_git
   cd vid.stab_git
@@ -1930,6 +1955,12 @@ build_ffmpeg() {
 
   cd $output_dir
     apply_patch file://$patch_dir/frei0r_load-shared-libraries-dynamically.diff
+    wget https://raw.githubusercontent.com/OpenVisualCloud/SVT-HEVC/master/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+    git am 0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+    #wget https://raw.githubusercontent.com/OpenVisualCloud/SVT-AV1/master/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+    #git apply 0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+    #wget https://raw.githubusercontent.com/OpenVisualCloud/SVT-VP9/master/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-vp9-with-svt-hevc-av1.patch
+    #git apply 0001-Add-ability-for-ffmpeg-to-run-svt-vp9-with-svt-hevc-av1.patch
 
     if [ "$bits_target" = "32" ]; then
       local arch=x86
@@ -1951,6 +1982,9 @@ build_ffmpeg() {
       # Fix WinXP incompatibility by disabling Microsoft's Secure Channel, because Windows XP doesn't support TLS 1.1 and 1.2, but with GnuTLS or OpenSSL it does.  XP compat!
     fi
     config_options="$init_options --enable-libcaca --enable-gray --enable-libtesseract --enable-fontconfig --enable-gmp --enable-gnutls --enable-libass --enable-libbluray --enable-libbs2b --enable-libflite --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libilbc --enable-libmodplug --enable-libmp3lame --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopus --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libtheora --enable-libtwolame --enable-libvo-amrwbenc --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libzimg --enable-libzvbi --enable-libmysofa --enable-libaom --enable-libopenjpeg  --enable-libopenh264 --enable-liblensfun  --enable-libvmaf --enable-libsrt --enable-demuxer=dash --enable-libxml2"
+    config_options+=" --enable-libsvthevc"
+    #config_options+=" --enable-libsvtav1"
+    #config_options+=" --enable-libsvtvp9"
     if [[ $compiler_flavors != "native" ]]; then
       config_options+=" --enable-nvenc --enable-nvdec" # don't work OS X 
     fi
@@ -2161,6 +2195,9 @@ build_ffmpeg_dependencies() {
   build_libsamplerate # Needs libsndfile >= 1.0.6 and fftw >= 0.15.0 for tests. Uses dlfcn.
   build_librubberband # Needs libsamplerate, libsndfile, fftw and vamp_plugin. 'configure' will fail otherwise. Eventhough librubberband doesn't necessarily need them (libsndfile only for 'rubberband.exe' and vamp_plugin only for "Vamp audio analysis plugin"). How to use the bundled libraries '-DUSE_SPEEX' and '-DUSE_KISSFFT'?
   build_frei0r # Needs dlfcn. could use opencv...
+  build_svt-hevc
+  #build_svt-av1
+  #build_svt-vp9
   build_vidstab
   #build_facebooktransform360 # needs modified ffmpeg to use it
   build_libmysofa # Needed for FFmpeg's SOFAlizer filter (https://ffmpeg.org/ffmpeg-filters.html#sofalizer). Uses dlfcn.

--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1349,7 +1349,9 @@ build_svt-hevc() {
 
 build_svt-av1() {
   do_git_checkout https://github.com/OpenVisualCloud/SVT-AV1.git
-  cd SVT-AV1_git/Build
+  cd SVT-AV1_git
+  git apply $patch_dir/SVT-AV1-Windows-lowercase.patch
+  cd Build
     do_cmake_from_build_dir .. "-DCMAKE_BUILD_TYPE=Release"
     do_make_and_make_install
   cd ../..
@@ -1357,7 +1359,9 @@ build_svt-av1() {
 
 build_svt-vp9() {
   do_git_checkout https://github.com/OpenVisualCloud/SVT-VP9.git
-  cd SVT-VP9_git/Build
+  cd SVT-VP9_git
+  git apply $patch_dir/SVT-VP9-Windows-lowercase.patch
+  cd Build
     do_cmake_from_build_dir ..
     do_make_and_make_install
   cd ../..
@@ -1955,12 +1959,21 @@ build_ffmpeg() {
 
   cd $output_dir
     apply_patch file://$patch_dir/frei0r_load-shared-libraries-dynamically.diff
+    #SVT-HEVC
     wget https://raw.githubusercontent.com/OpenVisualCloud/SVT-HEVC/master/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
     git am 0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch
+    #Add SVT-AV1 to SVT-HEVC
     #wget https://raw.githubusercontent.com/OpenVisualCloud/SVT-AV1/master/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
     #git apply 0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+    #Add SVT-VP9 to SVT-HEVC & SVT-AV1
     #wget https://raw.githubusercontent.com/OpenVisualCloud/SVT-VP9/master/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-vp9-with-svt-hevc-av1.patch
     #git apply 0001-Add-ability-for-ffmpeg-to-run-svt-vp9-with-svt-hevc-av1.patch
+    #SVT-AV1 only
+    #wget https://raw.githubusercontent.com/OpenVisualCloud/SVT-AV1/master/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+    #git apply 0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+    #SVT-VP9 only
+    #wget https://raw.githubusercontent.com/OpenVisualCloud/SVT-VP9/master/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch
+    #git apply 0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch
 
     if [ "$bits_target" = "32" ]; then
       local arch=x86

--- a/patches/SVT-AV1-Windows-lowercase.patch
+++ b/patches/SVT-AV1-Windows-lowercase.patch
@@ -1,0 +1,26 @@
+diff --git a/Source/App/EncApp/EbAppMain.c b/Source/App/EncApp/EbAppMain.c
+index 40cc5a89..15bd81ef 100644
+--- a/Source/App/EncApp/EbAppMain.c
++++ b/Source/App/EncApp/EbAppMain.c
+@@ -24,7 +24,7 @@
+ #include "EbAppContext.h"
+ #include "EbTime.h"
+ #ifdef _WIN32
+-#include <Windows.h>
++#include <windows.h>
+ #else
+ #include <pthread.h>
+ #include <semaphore.h>
+diff --git a/Source/Lib/Common/Codec/EbThreads.h b/Source/Lib/Common/Codec/EbThreads.h
+index ffa8ca8b..b37803d8 100644
+--- a/Source/Lib/Common/Codec/EbThreads.h
++++ b/Source/Lib/Common/Codec/EbThreads.h
+@@ -9,7 +9,7 @@
+ #include "EbDefinitions.h"
+ 
+ #ifdef _WIN32
+-#include <Windows.h>
++#include <windows.h>
+ #endif
+ 
+ #ifdef __cplusplus

--- a/patches/SVT-VP9-Windows-lowercase.patch
+++ b/patches/SVT-VP9-Windows-lowercase.patch
@@ -1,0 +1,13 @@
+diff --git a/Source/Lib/Codec/EbThreads.h b/Source/Lib/Codec/EbThreads.h
+index 240eaa7..115a56d 100644
+--- a/Source/Lib/Codec/EbThreads.h
++++ b/Source/Lib/Codec/EbThreads.h
+@@ -10,7 +10,7 @@
+ #include "EbDefinitions.h"
+ 
+ #ifdef _WIN32
+-#include <Windows.h>
++#include <windows.h>
+ #endif
+ 
+ #ifdef __cplusplus


### PR DESCRIPTION
I also tried to add SVT-AV1 and SVT-VP9, but both of them said something about missing Windows.h, and don't know where to begin to resolve that, but my first uneducated guess would be some kind of cmake settings.  I ran this on ubuntu cross compiling for win64, and verified that the libsvt_hevc encoder works when running the ffmpeg executable on windows.

Some output from running build_svt-av1:
https://hastebin.com/gitafajami.txt