### PR TITLE
Build x265 with all bitdepths

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -2086,9 +2086,6 @@ build_ffmpeg() {
   if [[ "$non_free" = "y" ]]; then
     output_dir+="_with_fdk_aac"
   fi
-  if [[ $high_bitdepth == "y" ]]; then
-    output_dir+="_x26x_high_bitdepth"
-  fi
   if [[ $build_intel_qsv == "n" ]]; then
     output_dir+="_xp_compat"
   fi
@@ -2536,7 +2533,6 @@ while true; do
       --git-get-latest=y [do a git pull for latest code from repositories like FFmpeg--can force a rebuild if changes are detected]
       --build-x264-with-libav=n build x264.exe with bundled/included "libav" ffmpeg libraries within it
       --prefer-stable=y build a few libraries from releases instead of git master
-      --high-bitdepth=n Enable high bit depth for x264 (10 bits) and x265 (10 and 12 bits, x64 build. Not officially supported on x86 (win32), but enabled by disabling its assembly).
       --debug Make this script  print out each line as it executes
       --enable-gpl=[y] set to n to do an lgpl build
       --build-dependencies=y [builds the ffmpeg dependencies. Disable it when the dependencies was built once and can greatly reduce build time. ]
@@ -2562,9 +2558,8 @@ while true; do
     --disable-nonfree=* ) disable_nonfree="${1#*=}"; shift ;;
     # this doesn't actually "build all", like doesn't build 10 high-bit LGPL ffmpeg, but it does exercise the "non default" type build options...
     -a         ) compiler_flavors="multi"; build_mplayer=n; build_libmxf=y; build_mp4box=y; build_vlc=y; build_lsw=y; 
-                 high_bitdepth=y; build_ffmpeg_static=y; build_ffmpeg_shared=y; build_lws=y;
-                 disable_nonfree=n; git_get_latest=y; sandbox_ok=y; build_amd_amf=y; build_intel_qsv=y; 
-                 build_dvbtee=y; build_x264_with_libav=y; shift ;;
+                 build_ffmpeg_static=y; build_ffmpeg_shared=y; build_lws=y; disable_nonfree=n; git_get_latest=y; 
+                 sandbox_ok=y; build_amd_amf=y; build_intel_qsv=y; build_dvbtee=y; build_x264_with_libav=y; shift ;;
     -d         ) gcc_cpu_count=$cpu_count; disable_nonfree="y"; sandbox_ok="y"; compiler_flavors="win64"; git_get_latest="n"; shift ;;
     --compiler-flavors=* ) 
          compiler_flavors="${1#*=}"; 
@@ -2577,7 +2572,6 @@ while true; do
     --build-ffmpeg-shared=* ) build_ffmpeg_shared="${1#*=}"; shift ;;
     --prefer-stable=* ) prefer_stable="${1#*=}"; shift ;;
     --enable-gpl=* ) enable_gpl="${1#*=}"; shift ;;
-    --high-bitdepth=* ) high_bitdepth="${1#*=}"; shift ;;
     --build-dependencies=* ) build_dependencies="${1#*=}"; shift ;;
     --debug ) set -x; shift ;;
     -- ) shift; break ;;

--- a/docker/docker-entry.sh
+++ b/docker/docker-entry.sh
@@ -6,7 +6,7 @@ set -e
 
 OUTPUTDIR=/output
 
-./cross_compile_ffmpeg.sh --build-ffmpeg-shared=y --build-ffmpeg-static=y --disable-nonfree=n --build-intel-qsv=y --compiler-flavors=win64 --enable-gpl=y --high-bitdepth=n
+./cross_compile_ffmpeg.sh --build-ffmpeg-shared=y --build-ffmpeg-static=y --disable-nonfree=n --build-intel-qsv=y --compiler-flavors=win64 --enable-gpl=y
 
 mkdir -p $OUTPUTDIR/static/bin
 cp -R -f ./sandbox/win64/ffmpeg_git_with_fdk_aac/ffmpeg.exe $OUTPUTDIR/static/bin

--- a/patches/all_build.sh
+++ b/patches/all_build.sh
@@ -26,7 +26,7 @@ done
 ./cross_compile_ffmpeg.sh --compiler-flavors=multi --disable-nonfree=y --git-get-latest=n --build-ffmpeg-shared=y --build-ffmpeg-static=y $desired_ffmpeg_ver 
 ./cross_compile_ffmpeg.sh --compiler-flavors=multi --disable-nonfree=y --git-get-latest=n --build-ffmpeg-shared=y --build-ffmpeg-static=y --enable-gpl=n $desired_ffmpeg_ver  # lgpl
 ./cross_compile_ffmpeg.sh --compiler-flavors=multi --disable-nonfree=y --git-get-latest=n --build-intel-qsv=n --build-ffmpeg-shared=y --build-ffmpeg-static=y $desired_ffmpeg_ver # windows xp :|
-./cross_compile_ffmpeg.sh --compiler-flavors=multi --disable-nonfree=y --git-get-latest=n --build-ffmpeg-static=y --build-ffmpeg-shared=n --high-bitdepth=y $desired_ffmpeg_ver # high bitdepth
+./cross_compile_ffmpeg.sh --compiler-flavors=multi --disable-nonfree=y --git-get-latest=n --build-ffmpeg-static=y --build-ffmpeg-shared=n $desired_ffmpeg_ver # intel-qsv
 
 rm -rf sandbox/distros # free up space from any previous distros
 if [[ $1 != "" ]]; then

--- a/patches/all_zip_distros.sh
+++ b/patches/all_zip_distros.sh
@@ -64,15 +64,6 @@ create_zip() {
   zip -qr $1 $2 # without  -q for quiet it was kind of screen chatty
 }
 
-do_high_bitdepth_and_zip() {
-  copy_ffmpeg_binaries ./sandbox/win32/ffmpeg_git_x26x_high_bitdepth "$root/32-bit/ffmpeg-static-x26x-high-bitdepth"  
-  copy_ffmpeg_binaries ./sandbox/x86_64/ffmpeg_git_x26x_high_bitdepth "$root/64-bit/ffmpeg-static-x26x-high-bitdepth" 
-  cd sandbox/distros
-    create_zip ffmpeg.static.$date.32-bit.x26x-high-bitdepth.zip "$date_version/32-bit/ffmpeg-static-x26x-high-bitdepth/*"
-    create_zip ffmpeg.static.$date.64-bit.x26x-high-bitdepth.zip "$date_version/64-bit/ffmpeg-static-x26x-high-bitdepth/*"
-  cd ../..
-}
-
 do_xp_compat_and_zip() {
   copy_ffmpeg_binaries ./sandbox/win32/ffmpeg_git_xp_compat "$root/32-bit/ffmpeg-static-xp-compatible"
   copy_ffmpeg_binaries ./sandbox/x86_64/ffmpeg_git_xp_compat "$root/64-bit/ffmpeg-static-xp-compatible"
@@ -92,7 +83,6 @@ do_statics() {
 }
 
 do_statics
-do_high_bitdepth_and_zip
 do_xp_compat_and_zip
 do_shareds
 


### PR DESCRIPTION
I changed the x265 build to have all bitdepths (8bit+10bit+12bit) and also removed the high-bitdepth option as it would now only be used for renaming the ffmpeg directory.

With this x265 will be 8bit by default, but using a 10bit or 12bit -pix_fmt option with ffmpeg will switch to the main10 or main12 profiles.