### PR TITLE
Fix building with meson versions back to 0.49.2

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -144,8 +144,8 @@ check_missing_packages () {
     exit 1
   fi
   local meson_version=`meson --version`
-  if ! at_least_required_version "0.47" "${meson_version}"; then
-    echo "your meson version is too old $meson_version wanted 0.47"
+  if ! at_least_required_version "0.49.2" "${meson_version}"; then
+    echo "your meson version is too old $meson_version wanted 0.49.2"
     exit 1
   fi
   # also check missing "setup" so it's early LOL
@@ -538,7 +538,7 @@ do_meson() {
 generic_meson() {
     local extra_configure_options="$1"
     mkdir -pv build
-    do_meson "--prefix=${mingw_w64_x86_64_prefix} --libdir=${mingw_w64_x86_64_prefix}/lib --buildtype=release --strip --default-library=static --cross-file=${top_dir}/meson-cross.mingw.txt $extra_configure_options . build"
+    do_meson "--prefix=${mingw_w64_x86_64_prefix} --libdir=${mingw_w64_x86_64_prefix}/lib --buildtype=release --default-library=static --cross-file=${top_dir}/meson-cross.mingw.txt $extra_configure_options . build"
 }
 
 generic_meson_ninja_install() {
@@ -837,7 +837,7 @@ build_glib() {
     export CPPFLAGS="$CPPFLAGS -pthread -DGLIB_STATIC_COMPILATION"
     export CXXFLAGS="$CFLAGS" # Not certain this is needed, but it doesn't hurt
     export LDFLAGS="-L${mingw_w64_x86_64_prefix}/lib" # For some reason the frexp configure checks fail without this as math.h isn't found when cross-compiling; no negative impact for native builds
-    local meson_options="--prefix=${mingw_w64_x86_64_prefix} --libdir=${mingw_w64_x86_64_prefix}/lib --buildtype=release --strip --default-library=static -Dinternal_pcre=true -Dforce_posix_threads=true . build"
+    local meson_options="--prefix=${mingw_w64_x86_64_prefix} --libdir=${mingw_w64_x86_64_prefix}/lib --buildtype=release --default-library=static -Dinternal_pcre=true -Dforce_posix_threads=true . build"
     if [[ $compiler_flavors != "native" ]]; then
       get_local_meson_cross_with_propeties # Need to add flags to meson properties; otherwise ran into some issues
       meson_options+=" --cross-file=meson-cross.mingw.txt"
@@ -1005,7 +1005,7 @@ build_libvmaf() {
     export CXXFLAGS="$CFLAGS -pthread"
     export LDFLAGS="-pthread" # Needed here too for some reason
     mkdir build
-    local meson_options="--prefix=${mingw_w64_x86_64_prefix} --libdir=${mingw_w64_x86_64_prefix}/lib --buildtype=release --strip --default-library=static . build"
+    local meson_options="--prefix=${mingw_w64_x86_64_prefix} --libdir=${mingw_w64_x86_64_prefix}/lib --buildtype=release --default-library=static . build"
     if [[ $compiler_flavors != "native" ]]; then
       get_local_meson_cross_with_propeties # Need to add flags to meson properties; otherwise ran into some issues
       meson_options+=" --cross-file=meson-cross.mingw.txt"
@@ -1718,7 +1718,7 @@ build_dav1d() {
       apply_patch file://$patch_dir/david_no_asm.patch -p1 # XXX report
     fi
     cpu_count=1 # XXX report :|
-    local meson_options="--prefix=${mingw_w64_x86_64_prefix} --libdir=${mingw_w64_x86_64_prefix}/lib --buildtype=release --strip --default-library=static . build"
+    local meson_options="--prefix=${mingw_w64_x86_64_prefix} --libdir=${mingw_w64_x86_64_prefix}/lib --buildtype=release --default-library=static . build"
     if [[ $compiler_flavors != "native" ]]; then
       meson_options+=" --cross-file=${top_dir}/meson-cross.mingw.txt"
     fi


### PR DESCRIPTION
This is a redo of some of the fixes from #462 but reapplied to the latest master and retested with Meson versions from 0.49.2 to 0.55.0; the other changes were already fixed in VMAF upstream.

The _**--strip**_ option can break building static libraries and is ignored for static libraries in Meson 0.52.0 and up (mesonbuild/meson#5905).

The minimum Meson version is now also 0.49.2 as glib requires that. I should've caught this in the previous pull request which upgraded glib, but I missed it.