### PR TITLE
Fix doing a multi flavour build while using a ffmpeg source dir

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -2436,7 +2436,12 @@ build_ffmpeg() {
       echo "You will find redistributable archive .7z file in $cur_dir/redist"
     fi
     echo `date`
-  cd ..
+    
+  if [[ -z $ffmpeg_source_dir ]]; then
+    cd ..
+  else
+    cd "$work_dir"
+  fi
 }
 
 build_lsw() {
@@ -2789,8 +2794,9 @@ if [[ $compiler_flavors == "native" ]]; then
   #  bs2b doesn't use pkg-config, sndfile needed Carbon :|
   export CPATH=$cur_dir/cross_compilers/native/include:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Carbon.framework/Versions/A/Headers # C_INCLUDE_PATH
   export LIBRARY_PATH=$cur_dir/cross_compilers/native/lib
-  mkdir -p native
-  cd native
+  work_dir="$(realpath $cur_dir/native)"
+  mkdir -p "$work_dir"
+  cd "$work_dir"
     build_ffmpeg_dependencies
     build_ffmpeg
   cd ..
@@ -2809,8 +2815,9 @@ if [[ $compiler_flavors == "multi" || $compiler_flavors == "win32" ]]; then
   bits_target=32
   cross_prefix="$mingw_bin_path/i686-w64-mingw32-"
   make_prefix_options="CC=${cross_prefix}gcc AR=${cross_prefix}ar PREFIX=$mingw_w64_x86_64_prefix RANLIB=${cross_prefix}ranlib LD=${cross_prefix}ld STRIP=${cross_prefix}strip CXX=${cross_prefix}g++"
-  mkdir -p win32
-  cd win32
+  work_dir="$(realpath $cur_dir/win32)"
+  mkdir -p "$work_dir"
+  cd "$work_dir"
     build_ffmpeg_dependencies
     build_apps
   cd ..
@@ -2829,8 +2836,9 @@ if [[ $compiler_flavors == "multi" || $compiler_flavors == "win64" ]]; then
   bits_target=64
   cross_prefix="$mingw_bin_path/x86_64-w64-mingw32-"
   make_prefix_options="CC=${cross_prefix}gcc AR=${cross_prefix}ar PREFIX=$mingw_w64_x86_64_prefix RANLIB=${cross_prefix}ranlib LD=${cross_prefix}ld STRIP=${cross_prefix}strip CXX=${cross_prefix}g++"
-  mkdir -p win64
-  cd win64
+  work_dir="$(realpath $cur_dir/win64)"
+  mkdir -p "$work_dir"
+  cd "$work_dir"
     build_ffmpeg_dependencies
     build_apps
   cd ..


### PR DESCRIPTION
Using a ffmpeg source directory usually results in the working directory changing to be out of the sandbox due to the `cd ..` at the end of the build_ffmpeg function; this can result in the win64 build failing when compiling with the _**multi**_ flavour.

This change creates a new _**work_dir**_ variable that is used for tracking the working directory of the current compilation so a build of ffmpeg using a source directory can `cd` back to the appropriate path when done.

This should fix #469; I have tested it on Ubuntu 18.04 and 20.04.