### PR TITLE
Fix an issue with getting a local meson cross file

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -2144,17 +2144,29 @@ EOF
 
 get_local_meson_cross_with_propeties() {
   local local_dir="$1"
+  local c_args=
+  local cpp_args=
+  local link_args=
   if [[ -z $local_dir ]]; then
     local_dir="."
   fi
   cp ${top_dir}/meson-cross.mingw.txt "$local_dir"
+  if [[ -n "$CFLAGS" ]]; then
+    c_args="'$(echo ${CFLAGS} | sed "s/ /\',\'/g")'"
+  fi
+  if [[ -n "$CXXFLAGS" ]]; then
+    cpp_args="'$(echo ${CXXFLAGS} | sed "s/ /\',\'/g")'"
+  fi
+  if [[ -n "$LDFLAGS" ]]; then
+    link_args="'$(echo ${LDFLAGS} | sed "s/ /\',\'/g")'"
+  fi
   cat >> meson-cross.mingw.txt << EOF
 
 [properties]
-c_args = ['${CFLAGS// /\',\'}']
-c_link_args = ['${LDFLAGS// /\',\'}']
-cpp_args = ['${CXXFLAGS// /\',\'}']
-cpp_link_args = ['${LDFLAGS// /\',\'}']
+c_args = [$c_args]
+c_link_args = [$link_args]
+cpp_args = [$cpp_args]
+cpp_link_args = [$link_args]
 EOF
 }
 


### PR DESCRIPTION
Using the _**get_local_meson_cross_with_properties**_ function requires CFLAGS, CXXFLAGS, and LDFLAGS to all be set.  If any are empty they will end up as an empty string in the meson-cross.mingw.txt file which will cause a very unhelpful "Unable to determine dynamic linker" error from Meson.

This fixes that by ensuring that if any of those environment variables are unset then the appropriate list in the meson-cross.mingw.txt is properly empty and does not have an empty string.

I also fixed the pattern substitution issue for older Bash versions (4.2 and lower) by using @litzh's recommended echo and sed combination, so this should also fix #473.