### PR TITLE
Switch gmp mirror

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1035,7 +1035,7 @@ build_fontconfig() {
 }
 
 build_gmp() {
-  download_and_unpack_file https://gmplib.org/download/gmp/gmp-6.2.0.tar.xz
+  download_and_unpack_file https://ftp.gnu.org/pub/gnu/gmp/gmp-6.2.0.tar.xz
   cd gmp-6.2.0
     #export CC_FOR_BUILD=/usr/bin/gcc # Are these needed?
     #export CPP_FOR_BUILD=usr/bin/cpp


### PR DESCRIPTION
My builds sometimes fail to connect to gmplib.org. Switch URL to the main GNU mirror to avoid intermittent connection issues.