### PR TITLE
Add support for FFmpeg release branches like "release/4.3"

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -2265,7 +2265,8 @@ build_ffmpeg() {
     output_dir+="_lgpl"
   fi
   if [[ ! -z $ffmpeg_git_checkout_version ]]; then
-    output_dir+="_$ffmpeg_git_checkout_version"
+    local output_dir_version=$(echo ${ffmpeg_git_checkout_version} | sed "s/\//_/g")
+    output_dir+="_$output_dir_version"
   fi
 
   local postpend_configure_opts=""


### PR DESCRIPTION
Add support for FFmpeg release branches like "release/4.3"

The current implementation creates a versioned FFmpeg directory `ffmpeg_git_..._release/4.3` wich results in a failed build.
Let's substitude "/" with "_" in `$output_dir` so we get `ffmpeg_git_..._release_4.3`.