### PR TITLE
Fix ffmpeg windres bug

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -2306,6 +2306,7 @@ build_ffmpeg() {
 
   cd $output_dir
     apply_patch file://$patch_dir/frei0r_load-shared-libraries-dynamically.diff
+    apply_patch file://$patch_dir/ffmpeg-windres-fix.patch
     if [ "$bits_target" != "32" ]; then
     #SVT-HEVC
     git apply "../SVT-HEVC_git/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch"

--- a/patches/ffmpeg-windres-fix.patch
+++ b/patches/ffmpeg-windres-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/ffbuild/common.mak b/ffbuild/common.mak
+index e070b6b5e2..ab536e157d 100644
+--- ffbuild/common.mak
++++ ffbuild/common.mak
+@@ -90,7 +90,7 @@ COMPILE_MSA = $(call COMPILE,CC,MSAFLAGS)
+ 	-$(if $(ASMSTRIPFLAGS), $(STRIP) $(ASMSTRIPFLAGS) $@)
+ 
+ %.o: %.rc
+-	$(WINDRES) $(IFLAGS) --preprocessor "$(DEPWINDRES) -E -xc-header -DRC_INVOKED $(CC_DEPFLAGS)" -o $@ $<
++	$(WINDRES) $(IFLAGS) -o $@ $<
+ 
+ %.i: %.c
+ 	$(CC) $(CCFLAGS) $(CC_E) $<


### PR DESCRIPTION
The pre-process step to windres made no sense to me. The whole point of windres is to compile a resource file to an object file which can then be linked.

Telling windres to run gcc compilation on the generated resource object file _before_ it has been created seemed backwards, and was why the resource compilation step failed. Removing the pre-processing step fixes the issue.