### PR TITLE
Fix bash and kernel comparison

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -203,7 +203,7 @@ check_missing_packages () {
       then try again"
       exit 1
     fi
-    export MINIMUM_KERNEL_VERSION = "4.19.128"
+    export MINIMUM_KERNEL_VERSION="4.19.128"
     KERNVER=$(uname -a | awk -F'[ ]' '{ print $3 }' | awk -F- '{ print $1 }')
 
     if [ $KERNVER != $MINIMUM_KERNEL_VERSION ]; then

--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -206,7 +206,11 @@ check_missing_packages () {
     export MINIMUM_KERNEL_VERSION="4.19.128"
     KERNVER=$(uname -a | awk -F'[ ]' '{ print $3 }' | awk -F- '{ print $1 }')
 
-    if [ $KERNVER != $MINIMUM_KERNEL_VERSION ]; then
+    function version { # for version comparison @ stackoverflow.com/a/37939589
+      echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
+    }
+
+    if [ $(version $KERNVER) -lt $(version $MINIMUM_KERNEL_VERSION) ]; then
       echo "Windows Subsystem for Linux (WSL) detected - kernel not at minumum version required: $MINIMUM_KERNEL_VERSION
       Please update via windows update then try again"
       exit 1


### PR DESCRIPTION
Kernel comparison was only checking for an exact match `!=`, thus a greater version would fail the check
Changed it to a proper comparions with the help of [SO](https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash#4024263)