### PR TITLE
Use work_dir in applying SVT-HEVC patches

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -2316,17 +2316,16 @@ build_ffmpeg() {
     apply_patch file://$patch_dir/ffmpeg-windres-fix.patch
     if [ "$bits_target" != "32" ]; then
 
-      # SVT-HEVC
-      # OLD PATCHES
-      # git apply "../SVT-VP9_git/ffmpeg_plugin/master-0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch"
-      # git apply "../SVT-HEVC_git/ffmpeg_plugin/0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch"
+      # SVT-VP9
+      # git apply "$work_dir/SVT-VP9_git/ffmpeg_plugin/master-0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch"
 
+      # SVT-HEVC
       # Apply the correct patches based on version. Logic (n4.4 patch for n4.2, n4.3 and n4.4)  based on patch notes here:
       # https://github.com/OpenVisualCloud/SVT-HEVC/commit/b5587b09f44bcae70676f14d3bc482e27f07b773#diff-2b35e92117ba43f8397c2036658784ba2059df128c9b8a2625d42bc527dffea1
       if [[ $ffmpeg_git_checkout_version == *"master"* ]]; then
-        git apply "../SVT-HEVC_git/ffmpeg_plugin/master-0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch"
+        git apply "$work_dir/SVT-HEVC_git/ffmpeg_plugin/master-0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch"
       elif [[ $ffmpeg_git_checkout_version == *"n4.4"* ]] || [[ $ffmpeg_git_checkout_version == *"n4.3"* ]] || [[ $ffmpeg_git_checkout_version == *"n4.2"* ]]; then
-        git apply "../SVT-HEVC_git/ffmpeg_plugin/n4.4-0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch"
+        git apply "$work_dir/SVT-HEVC_git/ffmpeg_plugin/n4.4-0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch"
         git apply "$patch_dir/SVT-HEVC-0002-doc-Add-libsvt_hevc-encoder-docs.patch"  # upstream patch does not apply on current ffmpeg master
       else
         # PUT PATCHES FOR OTHER VERSIONS HERE


### PR DESCRIPTION
Use `$work_dir` instead of `../` in applying SVT-HEVC patches as `../` usually results in the working directory to be out of the sandbox, failing builds using `--ffmpeg-source-dir=`.

https://github.com/rdp/ffmpeg-windows-build-helpers/pull/478
https://github.com/AnimMouse/ffmpeg-autobuild/issues/274