### PR TITLE
Disable libdav1d on stable builds including 32 bit builds

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -2313,6 +2313,10 @@ build_ffmpeg() {
     postpend_configure_opts="--enable-static --disable-shared --prefix=${install_prefix}"
   fi
 
+  if [[ $ffmpeg_git_checkout_version == *"n4.4"* ]] || [[ $ffmpeg_git_checkout_version == *"n4.3"* ]] || [[ $ffmpeg_git_checkout_version == *"n4.2"* ]]; then
+    postpend_configure_opts="${postpend_configure_opts} --disable-libdav1d " # dav1d has diverged since
+  fi
+
   cd $output_dir
     apply_patch file://$patch_dir/frei0r_load-shared-libraries-dynamically.diff
     if [ "$bits_target" != "32" ]; then
@@ -2328,7 +2332,6 @@ build_ffmpeg() {
       elif [[ $ffmpeg_git_checkout_version == *"n4.4"* ]] || [[ $ffmpeg_git_checkout_version == *"n4.3"* ]] || [[ $ffmpeg_git_checkout_version == *"n4.2"* ]]; then
         git apply "$work_dir/SVT-HEVC_git/ffmpeg_plugin/n4.4-0001-lavc-svt_hevc-add-libsvt-hevc-encoder-wrapper.patch"
         git apply "$patch_dir/SVT-HEVC-0002-doc-Add-libsvt_hevc-encoder-docs.patch"  # upstream patch does not apply on current ffmpeg master
-        postpend_configure_opts="${postpend_configure_opts} --disable-libdav1d " # dav1d has diverged since
       else
         # PUT PATCHES FOR OTHER VERSIONS HERE
         :


### PR DESCRIPTION
Dav1d has diverged since, so stable builds are failing https://github.com/rdp/ffmpeg-windows-build-helpers/issues/591.
I saw you [disabled dav1d](https://github.com/rdp/ffmpeg-windows-build-helpers/commit/dd2de2e5573a3a3759b74c038cfec2e00f76cb9e#diff-e7c706509c0a0c2b3bffb6c3b5225dabaf63409a8952fa63985be062f3fbfcadR2330) on 64 bit builds, but 32 bit builds are still failing.
So I disabled dav1d also on 32 bit stable builds.