### PR TITLE
Restore VP8 encoding support

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1758,8 +1758,8 @@ build_libvpx() {
     else
       local config_options="--target=x86_64-win64-gcc"
     fi
-    export CROSS="$cross_prefix"  # XXX investigate/report ssse3? huh wuh?
-    do_configure "$config_options --prefix=$mingw_w64_x86_64_prefix --disable-ssse3 --enable-static --disable-shared --disable-examples --disable-tools --disable-docs --disable-unit-tests --enable-vp9-highbitdepth --extra-cflags=-fno-asynchronous-unwind-tables --extra-cflags=-mstackrealign" # fno for Error: invalid register for .seh_savexmm
+    export CROSS="$cross_prefix"  # VP8 encoder *requires* sse3 support
+    do_configure "$config_options --prefix=$mingw_w64_x86_64_prefix --enable-ssse3 --enable-static --disable-shared --disable-examples --disable-tools --disable-docs --disable-unit-tests --enable-vp9-highbitdepth --extra-cflags=-fno-asynchronous-unwind-tables --extra-cflags=-mstackrealign" # fno for Error: invalid register for .seh_savexmm
     do_make_and_make_install
     unset CROSS
   cd ..


### PR DESCRIPTION
libvpx VP8 encoder requires sse3 support. If not enabled, VP8 support is silently disabled. 

This should not pose a problem as CPUs as old as Intel Core 2s (last made some 13 years ago) have SSE3 support. There are some old Intel Atoms and Celerons as well as AMD Athlons that were produced until some 10 years ago that did not have SSE3 support; these CPUs are too weak to support VP8 encoding (or h.264/265 encoding for that matter) at reasonable speeds anyway.