### PR TITLE
Enable libvpx

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -2375,12 +2375,8 @@ build_ffmpeg() {
         fi
         config_options+=" --enable-libsvthevc"
         config_options+=" --enable-libsvtav1"
-        # config_options+=" --enable-libsvtvp9"
-        #aom must be disabled to use SVT-AV1, just below
-        #config_options+=" --enable-libsvtav1" #not currently working but compiles if configured
-
-        #config_options+=" --enable-libvpx"
-        #config_options+=" --enable-libsvtvp9" #not currently working but compiles if configured
+        # config_options+=" --enable-libsvtvp9" #not currently working but compiles if configured
+        config_options+=" --enable-libvpx"
       fi # else doesn't work/matter with 32 bit
     fi
     config_options+=" --enable-libaom"


### PR DESCRIPTION
`--enable-libvpx` got commented out on https://github.com/rdp/ffmpeg-windows-build-helpers/commit/00a73a1cd9f2cc797ef95d81eb8fa5834b25786e#diff-e7c706509c0a0c2b3bffb6c3b5225dabaf63409a8952fa63985be062f3fbfcadR2382

I don't know why libvpx got disabled, no problem compiling libvpx.