### PR TITLE
Set the branch of libmysofa to main

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1632,7 +1632,7 @@ build_vidstab() {
 }
 
 build_libmysofa() {
-  do_git_checkout https://github.com/hoene/libmysofa.git libmysofa_git
+  do_git_checkout https://github.com/hoene/libmysofa.git libmysofa_git "origin/main"
   cd libmysofa_git
     local cmake_params="-DBUILD_TESTS=0"
     if [[ $compiler_flavors == "native" ]]; then


### PR DESCRIPTION
The default branch of [hoene/libmysofa](https://github.com/hoene/libmysofa) was changed from `master` to `main`.
Fixes #651