### PR TITLE
Set docker platform

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM --platform=amd64 ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Explicitly set the docker platform to amd64. There are arm Ubuntu images, but this project won't currently build as-is in arm. This is necessary for environments which, when platform is not set, default to arm when pulling/building Docker images, e.g. Apple Silicon Macs.