### PR TITLE
Fix libvpx encoder missing and make SVT-HEVC only opt-in

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -2382,9 +2382,9 @@ build_ffmpeg() {
         config_options+=" --enable-libsvthevc"
         config_options+=" --enable-libsvtav1"
         # config_options+=" --enable-libsvtvp9" #not currently working but compiles if configured
-        config_options+=" --enable-libvpx"
       fi # else doesn't work/matter with 32 bit
     fi
+    config_options+=" --enable-libvpx"
     config_options+=" --enable-libaom"
 
     if [[ $compiler_flavors != "native" ]]; then

--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -2626,11 +2626,13 @@ build_ffmpeg_dependencies() {
   build_libsamplerate # Needs libsndfile >= 1.0.6 and fftw >= 0.15.0 for tests. Uses dlfcn.
   build_librubberband # Needs libsamplerate, libsndfile, fftw and vamp_plugin. 'configure' will fail otherwise. Eventhough librubberband doesn't necessarily need them (libsndfile only for 'rubberband.exe' and vamp_plugin only for "Vamp audio analysis plugin"). How to use the bundled libraries '-DUSE_SPEEX' and '-DUSE_KISSFFT'?
   build_frei0r # Needs dlfcn. could use opencv...
-  if [[ "$bits_target" != "32" && $build_svt_hevc = "y" ]]; then
-    build_svt-hevc
+  if [[ "$bits_target" != "32" ]]; then
+    if [[ $build_svt_hevc = y ]]; then
+      build_svt-hevc
+    fi
+    build_svt-av1
+    #build_svt-vp9 # not currently working but compiles if configured
   fi
-  build_svt-av1
-  #build_svt-vp9 # not currently working but compiles if configured
   build_vidstab
   #build_facebooktransform360 # needs modified ffmpeg to use it so not typically useful
   build_libmysofa # Needed for FFmpeg's SOFAlizer filter (https://ffmpeg.org/ffmpeg-filters.html#sofalizer). Uses dlfcn.


### PR DESCRIPTION
The `--enable-libvpx` was located inside the `if [[ $build_svt = y ]]; then` conditional so disabling SVT will disable libvpx also, this will move `--enable-libvpx` outside that conditional.
Fixes https://github.com/AnimMouse/ffmpeg-autobuild/issues/627

SVT-HEVC are the only one that can cause breakage, other SVTs are pretty much stable, this will make SVT-HEVC only opt-in and allows other SVTs like SVT-AV1 to get built.
This will rename the variable `$build_svt` to `$build_svt_hevc` and rename the command line option `--build-svt` to `--build-svt-hevc`.

Fixes https://github.com/rdp/ffmpeg-windows-build-helpers/issues/603, fixes https://github.com/rdp/ffmpeg-windows-build-helpers/issues/413, fixes https://github.com/rdp/ffmpeg-windows-build-helpers/issues/630.