### PR TITLE
Use VSCode devcontainer to cross-compile FFmpeg

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
 FROM mcr.microsoft.com/devcontainers/base:debian
 # Install install packages necessary for ffmpeg crosscompile build
-RUN apt-get update && apt-get install -y subversion ragel curl texinfo g++ ed bison flex cvs yasm automake libtool autoconf gcc cmake git make pkg-config zlib1g-dev unzip pax nasm gperf autogen bzip2 autoconf-archive p7zip-full meson clang libtool-bin ed python3-distutils python-is-python3
+RUN apt-get update && apt-get install -y subversion ragel curl texinfo g++ ed bison flex cvs yasm automake libtool autoconf gcc cmake git make pkg-config zlib1g-dev unzip pax nasm gperf autogen bzip2 autoconf-archive p7zip-full meson clang libtool-bin ed python3-distutils python3-pip python-is-python3

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/base:debian
+# Install install packages necessary for ffmpeg crosscompile build
+RUN apt-get update && apt-get install -y subversion ragel curl texinfo g++ ed bison flex cvs yasm automake libtool autoconf gcc cmake git make pkg-config zlib1g-dev unzip pax nasm gperf autogen bzip2 autoconf-archive p7zip-full meson clang libtool-bin ed python3-distutils python-is-python3

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,11 @@
 FROM mcr.microsoft.com/devcontainers/base:debian
 # Install install packages necessary for ffmpeg crosscompile build
-RUN apt-get update && apt-get install -y subversion ragel curl texinfo g++ ed bison flex cvs yasm automake libtool autoconf gcc cmake git make pkg-config zlib1g-dev unzip pax nasm gperf autogen bzip2 autoconf-archive p7zip-full meson clang libtool-bin ed python3-distutils python3-pip python-is-python3
+RUN apt-get update && apt-get install -y \
+    subversion ragel curl texinfo g++ ed bison flex cvs yasm \
+    automake libtool autoconf gcc cmake git make pkg-config \
+    zlib1g-dev unzip pax nasm gperf autogen bzip2 autoconf-archive \
+    p7zip-full meson clang libtool-bin ed \
+    python3-distutils python3-pip python-is-python3 \
+    xorg-dev libgl1-mesa-dev libglu1-mesa-dev \
+    v4l-utils libv4l-dev \
+    libxcb-shm0-dev libxcb-shape0-dev libxcb-xfixes0-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,12 +8,6 @@
 		"dockerfile": "Dockerfile"
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/python:1": {
-			"installTools": true,
-			"version": "latest"
-		},
-		"ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {},
-		"ghcr.io/devcontainers-contrib/features/wget-apt-get:1": {},
 		"ghcr.io/guiyomh/features/vim:0": {}
 	}
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Debian",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	//"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {
+			"installTools": true,
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {},
+		"ghcr.io/devcontainers-contrib/features/wget-apt-get:1": {},
+		"ghcr.io/guiyomh/features/vim:0": {}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
Adds the files "devcontainer" and "Dockerfile" inside a .devcontainer folder to make this project buildable in a vscode devcontainer.  With this, a user of VSCode who has dev containers installed can simply clone this repo and build FFmpeg.

I'll understand if you are not interested given you do already have the docker configuration files, but since I'm using it this way I thought that I'd at least make it available.  Plus, it does provide a bit different functionality in that the user can shell into the container and make modifications.

It uses the base:debian image and installs (in the container) the prerequisites necessary to run the cross-compiler script, similar to what the existing Docker configuration files do in the current docker folder.

Instructions on how to configure your system to run this in a VSCode devcontainer can be found on the details page of the Dev Container extension for VSCode.

To run, from within VSCode select 'Clone Repository in Container Volume' using this repo's URL and follow the directions from there.  VSCode (and Docker) will clone this repo inside of a Debian based container with all the prerequisites necessary to run the cross-compile script.

When the container is ready, simply open a terminal in VSCode and run the script:

`$ ./cross_compile_ffmpeg.sh`

When the script has finished, the resulting FFmpeg executables can be copied out of the container with the following commands, where **\<container id\>** is the id of the container in docker (i.e. 'pensive_khayyam'):

```
$ docker cp <container id>:/workspaces/ffmpeg-windows-build-helpers/sandbox/win64/ffmpeg_git/ffmpeg.exe .
$ docker cp <container id>:/workspaces/ffmpeg-windows-build-helpers/sandbox/win64/ffmpeg_git/ffplay.exe .
$ docker cp <container id>:/workspaces/ffmpeg-windows-build-helpers/sandbox/win64/ffmpeg_git/ffprobe.exe .
```

All three builds (win32, win64, and native) build with default settings.
