### PR TITLE
fix: configure not detecting build machine on aarch64

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -351,7 +351,7 @@ install_cross_compiler() {
       if [[ `uname` =~ "5.1" ]]; then # Avoid using secure API functions for compatibility with msvcrt.dll on Windows XP.
         sed -i "s/ --enable-secure-api//" $zeranoe_script_name
       fi
-      nice ./$zeranoe_script_name $zeranoe_script_options --build-type=win32 || exit 1
+      CFLAGS=-O2 CXXFLAGS=-O2 nice ./$zeranoe_script_name $zeranoe_script_options --build-type=win32 || exit 1
       if [[ ! -f ../$win32_gcc ]]; then
         echo "Failure building 32 bit gcc? Recommend nuke sandbox (rm -rf sandbox) and start over..."
         exit 1
@@ -364,7 +364,7 @@ install_cross_compiler() {
     if [[ ($compiler_flavors == "win64" || $compiler_flavors == "multi") && ! -f ../$win64_gcc ]]; then
       echo "Building win64 x86_64 cross compiler..."
       download_gcc_build_script $zeranoe_script_name
-      nice ./$zeranoe_script_name $zeranoe_script_options --build-type=win64 || exit 1
+      CFLAGS=-O2 CXXFLAGS=-O2 nice ./$zeranoe_script_name $zeranoe_script_options --build-type=win64 || exit 1
       if [[ ! -f ../$win64_gcc ]]; then
         echo "Failure building 64 bit gcc? Recommend nuke sandbox (rm -rf sandbox) and start over..."
         exit 1
@@ -694,7 +694,9 @@ download_and_unpack_file() {
 }
 
 generic_configure() {
+  build_triple="${build_triple:-$(gcc -dumpmachine)}"
   local extra_configure_options="$1"
+  if [[ -n $build_triple ]]; then extra_configure_options+=" --build=$build_triple"; fi
   do_configure "--host=$host_target --prefix=$mingw_w64_x86_64_prefix --disable-shared --enable-static $extra_configure_options"
 }
 


### PR DESCRIPTION
This commit adds a `--build` for calls to configure in `generic_configure`, using the value obtained from `gcc -dumpmachine`.

On x86_64, all the configure scripts are able to detect the build machine correctly; in Arm aarch64, bs2b fails with the following message:

```output
unzipping libbs2b-3.1.0.tar.gz ...
configuring libbs2b-3.1.0 (/parent/ffmpeg/rdp/sandbox/win64/libbs2b-3.1.0) as $ PKG_CONFIG_PATH=/parent/ffmpeg/rdp/sandbox/cross_compilers/mingw-w64-x86_64/x86_64-w64-mingw32/lib/pkgconfig PATH=/parent/ffmpeg/rdp/sandbox/cross_compilers/mingw-w64-x86_64/bin:$PATH ./configure --host=x86_64-w64-mingw32 --prefix=/parent/ffmpeg/rdp/sandbox/cross_compilers/mingw-w64-x86_64/x86_64-w64-mingw32 --disable-shared --enable-static 
all touch files already_configured* touchname= already_configured_00c87be795485e939d1d23c84d477351-
config options --host=x86_64-w64-mingw32 --prefix=/parent/ffmpeg/rdp/sandbox/cross_compilers/mingw-w64-x86_64/x86_64-w64-mingw32 --disable-shared --enable-static ./configure
configure: WARNING: If you wanted to set the --build type, don't use --host.
    If a cross compiler is detected then cross compile mode will be used.
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
# [...]
checking dependency style of x86_64-w64-mingw32-gcc... gcc3
checking build system type... build-aux/config.guess: unable to guess system type

This script, last modified 2009-06-03, has failed to recognize
the operating system you are using. It is advised that you
download the most up to date version of the config scripts from

  http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD
and
  http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD

If the version you run (build-aux/config.guess) is already up to date, please
send the following data and any information you think might be
pertinent to <config-patches@gnu.org> in order to provide the needed
information to handle your system.

config.guess timestamp = 2009-06-03

uname -m = aarch64
uname -r = 6.2.10-1-aarch64-ARCH
uname -s = Linux
uname -v = #1 SMP PREEMPT_DYNAMIC Fri Apr  7 10:32:52 MDT 2023

/usr/bin/uname -p = aarch64
/bin/uname -X     = 

hostinfo               = 
/bin/universe          = 
/usr/bin/arch -k       = 
/bin/arch              = aarch64
/usr/bin/oslevel       = 
/usr/convex/getsysinfo = 

UNAME_MACHINE = aarch64
UNAME_RELEASE = 6.2.10-1-aarch64-ARCH
UNAME_SYSTEM  = Linux
UNAME_VERSION = #1 SMP PREEMPT_DYNAMIC Fri Apr  7 10:32:52 MDT 2023
configure: error: cannot guess build type; you must specify one
failed configure libbs2b-3.1.0
```

Adding the `--build` flag fixes this.

This commit also runs the zeranoe mingw build script with `CFLAGS=-O2 CXXFLAGS=-O2` which seems to cut the overall compilation time.
