### PR TITLE
If NotABug.org server is down , Change to use GitLab.com . for decklink-headers

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1657,7 +1657,14 @@ build_libcaca() {
 }
 
 build_libdecklink() {
-  do_git_checkout https://notabug.org/RiCON/decklink-headers.git
+  local url=https://notabug.org/RiCON/decklink-headers.git
+  git ls-remote $url
+  if [ $? -ne 0 ]; then
+    # If NotABug.org server is down , Change to use GitLab.com .
+    # https://gitlab.com/m-ab-s/decklink-headers
+    url=https://gitlab.com/m-ab-s/decklink-headers.git
+  fi
+  do_git_checkout $url
   cd decklink-headers_git
     do_make_install PREFIX=$mingw_w64_x86_64_prefix
   cd ..


### PR DESCRIPTION
At 2023/10/20 - 10/21
decklink-headers NotABug.org Git server is down
https://www.saashub.com/notabug-org-status
![image](https://github.com/rdp/ffmpeg-windows-build-helpers/assets/16265606/7c8f0c39-2b8b-41b0-89d1-caa2bcf3b210)

https://notabug.org/RiCON/decklink-headers.git
![image](https://github.com/rdp/ffmpeg-windows-build-helpers/assets/16265606/5bb0c23f-9dc7-4c99-b1ed-543172c27373)

I suggest the workaround below .
If NotABug.org server is down , Change to use GitLab.com .
https://gitlab.com/m-ab-s/decklink-headers

I tested gitlab.com's can also build FFmpeg .
(But not tested running . Because I don't have any Blackmagic Design products .)