### PR TITLE
Fix libaribcaption and nvenc on old versions of FFmpeg

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -847,7 +847,12 @@ build_amd_amf_headers() {
 }
 
 build_nv_headers() {
-  do_git_checkout https://github.com/FFmpeg/nv-codec-headers.git
+  if [[ $ffmpeg_git_checkout_version == *"n6.0"* ]] || [[ $ffmpeg_git_checkout_version == *"n5.1"* ]] || [[ $ffmpeg_git_checkout_version == *"n5.0"* ]] || [[ $ffmpeg_git_checkout_version == *"n4.4"* ]] || [[ $ffmpeg_git_checkout_version == *"n4.3"* ]] || [[ $ffmpeg_git_checkout_version == *"n4.2"* ]] || [[ $ffmpeg_git_checkout_version == *"n4.1"* ]] || [[ $ffmpeg_git_checkout_version == *"n3.4"* ]] || [[ $ffmpeg_git_checkout_version == *"n3.2"* ]] || [[ $ffmpeg_git_checkout_version == *"n2.8"* ]]; then
+    # nv_headers for old versions
+    do_git_checkout https://github.com/FFmpeg/nv-codec-headers.git nv-codec-headers_git n12.0.16.1
+  else
+    do_git_checkout https://github.com/FFmpeg/nv-codec-headers.git
+  fi
   cd nv-codec-headers_git
     do_make_install "PREFIX=$mingw_w64_x86_64_prefix" # just copies in headers
   cd ..
@@ -2419,7 +2424,8 @@ build_ffmpeg() {
       config_options+=" --disable-libmfx"
     fi
     
-    if [[ $ffmpeg_git_checkout_version != *"n6.0"* ]] && [[ $ffmpeg_git_checkout_version != *"n5.1"* ]] && [[ $ffmpeg_git_checkout_version != *"n5.0"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.4"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.3"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.2"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.1"* ]] && [[ $ffmpeg_git_checkout_version != *"n3.4"* ]] && [[ $ffmpeg_git_checkout_version != *"n3.2"* ]] && [[ $ffmpeg_git_checkout_version != *"n2.8"* ]]; then # Disable libaribcatption on old versions
+    if [[ $ffmpeg_git_checkout_version != *"n6.0"* ]] && [[ $ffmpeg_git_checkout_version != *"n5.1"* ]] && [[ $ffmpeg_git_checkout_version != *"n5.0"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.4"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.3"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.2"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.1"* ]] && [[ $ffmpeg_git_checkout_version != *"n3.4"* ]] && [[ $ffmpeg_git_checkout_version != *"n3.2"* ]] && [[ $ffmpeg_git_checkout_version != *"n2.8"* ]]; then
+      # Disable libaribcatption on old versions
       config_options+=" --enable-libaribcaption" # libaribcatption (MIT licensed)
     fi
     

--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -2419,7 +2419,7 @@ build_ffmpeg() {
       config_options+=" --disable-libmfx"
     fi
     
-    if [[ $ffmpeg_git_checkout_version != *"n6.0"* ]] || [[ $ffmpeg_git_checkout_version != *"n5.1"* ]] || [[ $ffmpeg_git_checkout_version != *"n5.0"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.4"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.3"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.2"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.1"* ]] || [[ $ffmpeg_git_checkout_version != *"n3.4"* ]] || [[ $ffmpeg_git_checkout_version != *"n3.2"* ]] || [[ $ffmpeg_git_checkout_version != *"n2.8"* ]]; then
+    if [[ $ffmpeg_git_checkout_version != *"n6.0"* ]] && [[ $ffmpeg_git_checkout_version != *"n5.1"* ]] && [[ $ffmpeg_git_checkout_version != *"n5.0"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.4"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.3"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.2"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.1"* ]] && [[ $ffmpeg_git_checkout_version != *"n3.4"* ]] && [[ $ffmpeg_git_checkout_version != *"n3.2"* ]] && [[ $ffmpeg_git_checkout_version != *"n2.8"* ]]; then # Disable libaribcatption on old versions
       config_options+=" --enable-libaribcaption" # libaribcatption (MIT licensed)
     fi
     
@@ -2662,7 +2662,7 @@ build_ffmpeg_dependencies() {
 
   build_libxvid # FFmpeg now has native support, but libxvid still provides a better image.
   build_libsrt # requires gnutls, mingw-std-threads
-  if [[ $ffmpeg_git_checkout_version != *"n6.0"* ]] || [[ $ffmpeg_git_checkout_version != *"n5.1"* ]] || [[ $ffmpeg_git_checkout_version != *"n5.0"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.4"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.3"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.2"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.1"* ]] || [[ $ffmpeg_git_checkout_version != *"n3.4"* ]] || [[ $ffmpeg_git_checkout_version != *"n3.2"* ]] || [[ $ffmpeg_git_checkout_version != *"n2.8"* ]]; then
+  if [[ $ffmpeg_git_checkout_version != *"n6.0"* ]] && [[ $ffmpeg_git_checkout_version != *"n5.1"* ]] && [[ $ffmpeg_git_checkout_version != *"n5.0"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.4"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.3"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.2"* ]] && [[ $ffmpeg_git_checkout_version != *"n4.1"* ]] && [[ $ffmpeg_git_checkout_version != *"n3.4"* ]] && [[ $ffmpeg_git_checkout_version != *"n3.2"* ]] && [[ $ffmpeg_git_checkout_version != *"n2.8"* ]]; then
     build_libaribcaption
   fi
   build_libaribb24

--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -2418,7 +2418,11 @@ build_ffmpeg() {
     else
       config_options+=" --disable-libmfx"
     fi
-    config_options+=" --enable-libaribcaption" # libaribcatption (MIT licensed)
+    
+    if [[ $ffmpeg_git_checkout_version != *"n6.0"* ]] || [[ $ffmpeg_git_checkout_version != *"n5.1"* ]] || [[ $ffmpeg_git_checkout_version != *"n5.0"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.4"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.3"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.2"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.1"* ]] || [[ $ffmpeg_git_checkout_version != *"n3.4"* ]] || [[ $ffmpeg_git_checkout_version != *"n3.2"* ]] || [[ $ffmpeg_git_checkout_version != *"n2.8"* ]]; then
+      config_options+=" --enable-libaribcaption" # libaribcatption (MIT licensed)
+    fi
+    
     if [[ $enable_gpl == 'y' ]]; then
       config_options+=" --enable-gpl --enable-frei0r --enable-librubberband --enable-libvidstab --enable-libx264 --enable-libx265 --enable-avisynth --enable-libaribb24"
       config_options+=" --enable-libxvid --enable-libdavs2"
@@ -2658,7 +2662,9 @@ build_ffmpeg_dependencies() {
 
   build_libxvid # FFmpeg now has native support, but libxvid still provides a better image.
   build_libsrt # requires gnutls, mingw-std-threads
-  build_libaribcaption
+  if [[ $ffmpeg_git_checkout_version != *"n6.0"* ]] || [[ $ffmpeg_git_checkout_version != *"n5.1"* ]] || [[ $ffmpeg_git_checkout_version != *"n5.0"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.4"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.3"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.2"* ]] || [[ $ffmpeg_git_checkout_version != *"n4.1"* ]] || [[ $ffmpeg_git_checkout_version != *"n3.4"* ]] || [[ $ffmpeg_git_checkout_version != *"n3.2"* ]] || [[ $ffmpeg_git_checkout_version != *"n2.8"* ]]; then
+    build_libaribcaption
+  fi
   build_libaribb24
   build_libtesseract
   build_lensfun  # requires png, zlib, iconv


### PR DESCRIPTION
Fixes `Unknown option "--enable-libaribcaption".` by not building libaribcaption on old versions of FFmpeg.
Fixes #701, fixes https://github.com/AnimMouse/ffmpeg-stable-autobuild/issues/116.

Fixes `ERROR: nvenc requested but not found` by checking out a specific version of nv-codec-headers on old versions of FFmpeg with credits to #714.
Fixes #708, fixes #712.