### PR TITLE
fix: xavs configuration was non-executable

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -513,6 +513,7 @@ do_configure() {
       autoreconf -fiv # a handful of them require this to create ./configure :|
     fi
     rm -f already_* # reset
+    chmod u+x "$configure_name" # In non-windows environments, with devcontainers, the configuration file doesn't have execution permissions
     nice -n 5 "$configure_name" $configure_options || { echo "failed configure $english_name"; exit 1;} # less nicey than make (since single thread, and what if you're running another ffmpeg nice build elsewhere?)
     touch -- "$touch_name"
     echo "doing preventative make clean"


### PR DESCRIPTION
I discovered when you try and run the build on macos in the dev container the configuration file in `xavs_svn` doesn't have the executable permissions, this just simply adds it

Tested a build on windows dev container and on macos too, gets past this error now :)