### PR TITLE
fix: libbs2b building on aarch64

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1525,6 +1525,7 @@ build_libbluray() {
 build_libbs2b() {
   download_and_unpack_file https://downloads.sourceforge.net/project/bs2b/libbs2b/3.1.0/libbs2b-3.1.0.tar.gz
   cd libbs2b-3.1.0
+    apply_patch file://$patch_dir/libbs2b.patch
     sed -i.bak "s/AC_FUNC_MALLOC//" configure.ac # #270
     export LIBS=-lm # avoid pow failure linux native
     generic_configure_make_install

--- a/patches/libbs2b.patch
+++ b/patches/libbs2b.patch
@@ -1,0 +1,13 @@
+diff -crB build-aux/config.sub.orig build-aux/config.sub > libbs2b.patch
+*** build-aux/config.sub.orig	2024-07-03 02:18:03.887685830 +0000
+--- build-aux/config.sub	2024-07-03 02:16:45.485027716 +0000
+***************
+*** 242,247 ****
+--- 242,248 ----
+  	| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] | alpha64pca5[67] \
+  	| am33_2.0 \
+  	| arc | arm | arm[bl]e | arme[lb] | armv[2345] | armv[345][lb] | avr | avr32 \
++ 	| aarch64 \
+  	| bfin \
+  	| c4x | clipper \
+  	| d10v | d30v | dlx | dsp16xx | dvp \


### PR DESCRIPTION
When building on a devcontainer on macos this error occurs:
```
checking build system type... Invalid configuration `aarch64-linux-gnu': machine `aarch64' not recognized
configure: error: /bin/bash ./build-aux/config.sub aarch64-linux-gnu failed
failed configure libbs2b-3.1.0
```

This patch adds the missing arch, and the build now works

Tested on windows and on macos