### PR TITLE
fix: zvbi building on aarch64

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -1718,6 +1718,7 @@ build_zvbi() {
       apply_patch file://$patch_dir/zvbi-win32.patch
     fi
     apply_patch file://$patch_dir/zvbi-no-contrib.diff # weird issues with some stuff in contrib...
+    apply_patch file://$patch_dir/zvbi-aarch64.patch
     generic_configure " --disable-dvb --disable-bktr --disable-proxy --disable-nls --without-doxygen --without-libiconv-prefix"
     # Without '--without-libiconv-prefix' 'configure' would otherwise search for and only accept a shared Libiconv library.
     do_make_and_make_install

--- a/patches/zvbi-aarch64.patch
+++ b/patches/zvbi-aarch64.patch
@@ -1,0 +1,12 @@
+*** config.sub.orig	2024-07-03 04:22:41.228137888 +0000
+--- config.sub	2024-07-03 04:23:00.532309839 +0000
+***************
+*** 250,255 ****
+--- 250,256 ----
+  	| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] | alpha64pca5[67] \
+  	| am33_2.0 \
+  	| arc | arm | arm[bl]e | arme[lb] | armv[2345] | armv[345][lb] | avr | avr32 \
++ 	| aarch64 \
+  	| bfin \
+  	| c4x | clipper \
+  	| d10v | d30v | dlx | dsp16xx \


### PR DESCRIPTION
When building on a devcontainer on macos this error occurs:
```
checking build system type... Invalid configuration `aarch64-linux-gnu': machine `aarch64' not recognized
configure: error: /bin/bash ./config.sub aarch64-linux-gnu failed
failed configure zvbi-0.2.35
```

This patch adds the missing arch, and the build now works

Tested on windows and on macos