### PR TITLE
Remove Obsolete Package Suggestion

### DIFF
--- a/cross_compile_ffmpeg.sh
+++ b/cross_compile_ffmpeg.sh
@@ -94,9 +94,6 @@ check_missing_packages () {
         echo "for ubuntu:"
         echo "$ sudo apt-get update"
         ubuntu_ver="$(lsb_release -rs)"
-        if at_least_required_version "18.04" "$ubuntu_ver"; then
-          apt_pkgs="$apt_pkgs python3-distutils" # guess it's no longer built-in, lensfun requires it...
-        fi
         if at_least_required_version "20.04" "$ubuntu_ver"; then
           apt_pkgs="$apt_pkgs python-is-python3" # needed
         fi


### PR DESCRIPTION
Closes https://github.com/EnsignPayton/ffmpeg-windows-build-helpers/issues/1

Probably merits deprecation of Ubuntu 18.04. Might get upstreamed considering [this](https://github.com/rdp/ffmpeg-windows-build-helpers/issues/452#issuecomment-2829085913)
